### PR TITLE
Fix the ABI interface

### DIFF
--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -52,8 +52,8 @@ export interface IABI {
 	readonly inputs: IInput[];
 	readonly name: string;
 	readonly outputs?: any[];
-	readonly payable: any;
-	readonly stateMutability: any;
+	readonly payable?: any;
+	readonly stateMutability?: any;
 	readonly type: any;
 }
 


### PR DESCRIPTION
You should consider the JSON object of an `event` description, the JSON object of the `event` is similar to `function`, but have less field.

reference: https://solidity.readthedocs.io/en/v0.5.3/abi-spec.html#json